### PR TITLE
Relocated function call

### DIFF
--- a/connections/ldap.php
+++ b/connections/ldap.php
@@ -47,11 +47,12 @@ function AuthenticateUser($netid, $password) {
                 }
                 // Select first record in result (should only be one)
                 $entry = @ldap_first_entry($connection, $result);
-                @ldap_free_result($result);
+                //DO NOT ATTEMPT TO CLEAR $result UNTIL SOMETIME AFTER THE if() STATEMENT
                 if (!$entry) {
                     throw new Exception(@ldap_error($connection), @ldap_errno($connection));
                 }
                 // Grab attribute value from record
+                @ldap_free_result($result);             //DO NOT PUT THIS RIGHT NEXT TO THE ldap_search() CALL, CRASHES SERVER
                 $uta_id = @ldap_get_values($connection, $entry, $attribute);
                 if (!$uta_id) {
                     //throw new Exception(@ldap_error($connection), @ldap_errno($connection));


### PR DESCRIPTION
Shifted the ldap_free_result() call down below the next if statement - appears to work fine there.  Having ldap_free_result() directly under the "$entry=@ldap_first_entry($connection, $result)" statement was fully legal in 5.6 and appeared to work fine in 7.3(though that was on my local env, NOT official hosting), but for 7.2 the ldap_first_entry() call seems to hang on to and protect the variable after it's been called and the assignment has been performed, and a memory access error occurs that kills PHP so fast and hard it doesn't even write error_log calls put into code for diagnostics.