### PR TITLE
Fix issue with cost total

### DIFF
--- a/pages/end.php
+++ b/pages/end.php
@@ -501,7 +501,7 @@ include_once($_SERVER['DOCUMENT_ROOT'].'/pages/footer.php');
 				var min_quant = parseFloat(this.element['min'].value) / 60;
 				if(isNaN(hour_quant)) hour_quant = 0;  // Esau found this bug
 				if(isNaN(min_quant)) min_quant = 0;
-				return hour_quant + min_quant / 60;
+				return hour_quant + min_quant;
 			}
 			else
 			{


### PR DESCRIPTION
After looking through the files and talking to Matt it turns out that the issue was that the return value on line 504 was dividing the quantity already divied on line 501. This is now fixed.